### PR TITLE
Fix typos in database names

### DIFF
--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -226,7 +226,7 @@ export default function CVPage() {
                 description={
                   <ul className="ml-4 list-disc text-sm text-white/70">
                     <li>Development of Backend Services using Rust (actix-web) and Python (Django, Flask and FastAPI).</li>
-                    <li>Distributed Deployment and Monitoring of Microservices using Docker, PostgresSQL, Redis and ElasticSearch.</li>
+                    <li>Distributed Deployment and Monitoring of Microservices using Docker, PostgreSQL, Redis and Elasticsearch.</li>
                     <li>Developed Aptoide&apos;s performance-critical Mobile Measurement Platform in Rust.</li>
                   </ul>
                 }

--- a/src/app/cv/technical-skills.tsx
+++ b/src/app/cv/technical-skills.tsx
@@ -5,7 +5,7 @@ import { Cpu } from "lucide-react"
 const skills = [
     { category: "Programming Languages", items: ["Python", "Rust", "Go", "JavaScript", "TypeScript", "Java 🤢"] },
     { category: "Web Technologies", items: ["React", "Next.js", "Node.js", "HTML", "CSS", "TailwindCSS"] },
-    { category: "Databases", items: ["PostgresSQL", "MySQL", "SQlite", "MongoDB", "Redis", "ElasticSearch"] },
+    { category: "Databases", items: ["PostgreSQL", "MySQL", "SQLite", "MongoDB", "Redis", "Elasticsearch"] },
     { category: "DevOps & Tools", items: ["Docker", "Kubernetes", "Git", "CI/CD", "Linux", "Bash"] },
     {
         category: "Concepts",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ const skills = [
   "TypeScript",
   "React",
   "TailwindCSS",
-  "PostgresSQL", "MySQL", "SQlite", "Redis",
+  "PostgreSQL", "MySQL", "SQLite", "Redis",
   "Node.js",
   "Docker",
   "Kubernetes",


### PR DESCRIPTION
## Summary
- correct typos in database names on the homepage
- fix same typos in CV pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68652b7a7a388329b2ab64ad9a7ee3f0