### PR TITLE
Fix slug params interface

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 interface BlogPostPageProps {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }
 
 // TODO: make this import data from a CMS
@@ -15,7 +15,7 @@ const blogPosts = {
 }
 
 export default async function BlogPost({ params }: BlogPostPageProps) {
-  const { slug } = await params;
+  const { slug } = params;
   const post = blogPosts[slug as keyof typeof blogPosts]
 
   if (!post) {


### PR DESCRIPTION
## Summary
- refactor blog post page props to have direct slug property
- simplify slug extraction in the component

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68652d8293cc8329b4403256f9373a02